### PR TITLE
Compatibility ggplot2 3.6.0

### DIFF
--- a/tests/testthat/test_category_contribution.R
+++ b/tests/testthat/test_category_contribution.R
@@ -1,4 +1,11 @@
 p <- category_contribution(ggplot2::diamonds, cut, price)
+
+labels <- if ("get_labs" %in% getNamespaceExports("ggplot2")) {
+  ggplot2::get_labs(p)
+} else {
+  p$labels
+}
+
 test_that("Plot layers match expectations",{
   expect_is(p$layers[[1]], "ggproto")
 })
@@ -12,12 +19,12 @@ test_that("Plot uses correct data",{
 })
 
 test_that("x axis is labeled 'cut'",{
-  expect_match(p$labels$x, "cut")
+  expect_match(labels$x, "cut")
 })
 
 
 test_that("y axis is labeled 'total_price' -- 2",{
-  expect_match(p$labels$y, "total_price")
+  expect_match(labels$y, "total_price")
 })
 
 

--- a/tests/testthat/test_category_tally.R
+++ b/tests/testthat/test_category_tally.R
@@ -1,4 +1,11 @@
 p <- category_tally(ggplot2::mpg, class)
+
+labels <- if ("get_labs" %in% getNamespaceExports("ggplot2")) {
+  ggplot2::get_labs(p)
+} else {
+  p$labels
+}
+
 test_that("Plot layers match expectations",{
   expect_is(p$layers[[1]], "ggproto")
 })
@@ -12,11 +19,11 @@ test_that("Plot uses correct data",{
 })
 
 test_that("x axis is labeled 'class'",{
-  expect_match(p$labels$x, "class")
+  expect_match(labels$x, "class")
 })
 
 test_that("y axis is labeled 'count'",{
-  expect_match(p$labels$y, "count")
+  expect_match(labels$y, "count")
 })
 
 

--- a/tests/testthat/test_measure_change_over_time_long.R
+++ b/tests/testthat/test_measure_change_over_time_long.R
@@ -1,4 +1,11 @@
 p <- measure_change_over_time_long(ggplot2::economics_long, date, variable, value, pop, unemploy)
+
+labels <- if ("get_labs" %in% getNamespaceExports("ggplot2")) {
+  ggplot2::get_labs(p)
+} else {
+  p$labels
+}
+
 test_that("Plot layers match expectations",{
   expect_is(p$layers[[1]], "ggproto")
 })
@@ -11,11 +18,11 @@ test_that("Plot uses correct data",{
   expect_equal(TRUE, all(c("date", "variable", "value") %in% names(p$data)))
 })
 test_that("x axis is labeled 'date'",{
-  expect_match(p$labels$x, "date")
+  expect_match(labels$x, "date")
 })
 
 test_that("y axis is labeled 'value'",{
-  expect_match(p$labels$y, "value")
+  expect_match(labels$y, "value")
 })
 
 

--- a/tests/testthat/test_measure_change_over_time_wide.R
+++ b/tests/testthat/test_measure_change_over_time_wide.R
@@ -1,4 +1,11 @@
 p <- measure_change_over_time_wide(ggplot2::economics, date, pop, unemploy)
+
+labels <- if ("get_labs" %in% getNamespaceExports("ggplot2")) {
+  ggplot2::get_labs(p)
+} else {
+  p$labels
+}
+
 test_that("Plot layers match expectations",{
   expect_is(p$layers[[1]], "ggproto")
 })
@@ -12,11 +19,11 @@ test_that("Plot uses correct data",{
 })
 
 test_that("x axis is labeled 'date'",{
-  expect_match(p$labels$x, "date")
+  expect_match(labels$x, "date")
 })
 
 test_that("y axis is labeled 'value'",{
-  expect_match(p$labels$y, "value")
+  expect_match(labels$y, "value")
 })
 
 

--- a/tests/testthat/test_measure_distribution.R
+++ b/tests/testthat/test_measure_distribution.R
@@ -1,6 +1,12 @@
 p <- measure_distribution(ggplot2::mpg, hwy)
 q <- measure_distribution(ggplot2::mpg, hwy, "hist")
 r <- measure_distribution(ggplot2::mpg, hwy, "box")
+
+get_labs <- function(x) x$labels
+if ("get_labs" %in% getNamespaceExports("ggplot2")) {
+  get_labs <- ggplot2::get_labs
+}
+
 test_that("Plot layers match expectations",{
   expect_is(p$layers[[1]], "ggproto")
   expect_is(q$layers[[1]], "ggproto")
@@ -20,15 +26,15 @@ test_that("Plot uses correct data",{
 })
 
 test_that("x axis label is hwy",{
-  expect_match(p$labels$x, "hwy")
-  expect_match(q$labels$x, "hwy")
-  expect_match(r$labels$x, "")
+  expect_match(get_labs(p)$x, "hwy")
+  expect_match(get_labs(q)$x, "hwy")
+  expect_match(get_labs(r)$x, "")
 })
 
 test_that("y axis label is correct",{
-  expect_match(p$labels$y, "count")
-  expect_match(q$labels$y, "count")
-  expect_match(r$labels$y, "hwy")
+  expect_match(get_labs(p)$y, "count")
+  expect_match(get_labs(q)$y, "count")
+  expect_match(get_labs(r)$y, "hwy")
 })
 
 test_that("Plot type is correct", {

--- a/tests/testthat/test_measure_distribution_by_category.R
+++ b/tests/testthat/test_measure_distribution_by_category.R
@@ -1,6 +1,12 @@
 p <- measure_distribution(ggplot2::mpg, hwy)
 q <- measure_distribution(ggplot2::mpg, hwy, "hist")
 r <- measure_distribution(ggplot2::mpg, hwy, "box")
+
+get_labs <- function(x) x$labels
+if ("get_labs" %in% getNamespaceExports("ggplot2")) {
+  get_labs <- ggplot2::get_labs
+}
+
 test_that("Plot layers match expectations",{
   expect_is(p$layers[[1]], "ggproto")
   expect_is(q$layers[[1]], "ggproto")
@@ -20,15 +26,15 @@ test_that("Plot uses correct data",{
 })
 
 test_that("x axis label is hwy",{
-  expect_match(p$labels$x, "hwy")
-  expect_match(q$labels$x, "hwy")
-  expect_match(r$labels$x, "")
+  expect_match(get_labs(p)$x, "hwy")
+  expect_match(get_labs(q)$x, "hwy")
+  expect_match(get_labs(r)$x, "")
 })
 
 test_that("y axis label is correct",{
-  expect_match(p$labels$y, "count")
-  expect_match(q$labels$y, "count")
-  expect_match(r$labels$y, "hwy")
+  expect_match(get_labs(p)$y, "count")
+  expect_match(get_labs(q)$y, "count")
+  expect_match(get_labs(r)$y, "hwy")
 })
 
 test_that("Plot type is correct", {

--- a/tests/testthat/test_measure_distribution_by_two_caregories.R
+++ b/tests/testthat/test_measure_distribution_by_two_caregories.R
@@ -1,4 +1,11 @@
 p <- measure_distribution_by_two_categories(ggplot2::mpg, hwy, class, fl)
+
+labels <- if ("get_labs" %in% getNamespaceExports("ggplot2")) {
+  ggplot2::get_labs(p)
+} else {
+  p$labels
+}
+
 test_that("Plot layers match expectations",{
   expect_is(p$layers[[1]], "ggproto")
 })
@@ -12,11 +19,11 @@ test_that("Plot uses correct data",{
 })
 
 test_that("x axis label is hwy",{
-  expect_match(p$labels$x, "hwy")
+  expect_match(labels$x, "hwy")
 })
 
 test_that("y axis label is correct",{
-  expect_match(p$labels$y, "count")
+  expect_match(labels$y, "count")
 })
 
 test_that("Facet type is correct", {

--- a/tests/testthat/test_measure_distribution_over_time.R
+++ b/tests/testthat/test_measure_distribution_over_time.R
@@ -5,6 +5,13 @@ h <- c(h1, h2, h3)
 y <- c(rep(1999, 50), rep(2000, 50), rep(2001, 50))
 df <- data.frame(height = h, year = y)
 p <- measure_distribution_over_time(df, h, year)
+
+labels <- if ("get_labs" %in% getNamespaceExports("ggplot2")) {
+  ggplot2::get_labs(p)
+} else {
+  p$labels
+}
+
 test_that("Plot layers match expectations",{
   expect_is(p$layers[[1]], "ggproto")
 })
@@ -18,11 +25,11 @@ test_that("Plot uses correct data",{
 })
 
 test_that("x axis label is h",{
-  expect_match(p$labels$x, "h")
+  expect_match(labels$x, "h")
 })
 
 test_that("y axis is labeled 'count'",{
-  expect_match(p$labels$y, "count")
+  expect_match(labels$y, "count")
 })
 
 test_that("Facet type is correct", {

--- a/tests/testthat/test_two_category_contribution.R
+++ b/tests/testthat/test_two_category_contribution.R
@@ -1,4 +1,11 @@
 p <- two_category_contribution(ggplot2::diamonds,  clarity, cut, price, separate = TRUE)
+
+labels <- if ("get_labs" %in% getNamespaceExports("ggplot2")) {
+  ggplot2::get_labs(p)
+} else {
+  p$labels
+}
+
 test_that("Plot layers match expectations",{
   expect_is(p$layers[[1]], "ggproto")
 })
@@ -12,11 +19,11 @@ test_that("Plot uses correct data",{
 })
 
 test_that("x axis is labeled 'clarity'",{
-  expect_match(p$labels$x, "clarity")
+  expect_match(labels$x, "clarity")
 })
 
 test_that("y axis is labeled 'total_price'",{
-  expect_identical(p$labels$y, "total_price")
+  expect_identical(labels$y, "total_price")
 })
 
 

--- a/tests/testthat/test_two_category_tally.R
+++ b/tests/testthat/test_two_category_tally.R
@@ -1,4 +1,11 @@
 p <- two_category_tally(ggplot2::mpg, class, drv)
+
+labels <- if ("get_labs" %in% getNamespaceExports("ggplot2")) {
+  ggplot2::get_labs(p)
+} else {
+  p$labels
+}
+
 test_that("Plot layers match expectations",{
   expect_is(p$layers[[1]], "ggproto")
 })
@@ -12,11 +19,11 @@ test_that("Plot uses correct data",{
 })
 
 test_that("x axis is labeled 'class'",{
-  expect_match(p$labels$x, "class")
+  expect_match(labels$x, "class")
 })
 
 test_that("y axis is labeled 'count'",{
-  expect_match(p$labels$y, "count")
+  expect_match(labels$y, "count")
 })
 
 

--- a/tests/testthat/test_two_measures_relationship.R
+++ b/tests/testthat/test_two_measures_relationship.R
@@ -1,4 +1,11 @@
 p <- two_measures_relationship(ggplot2::mpg, displ, hwy, class)
+
+labels <- if ("get_labs" %in% getNamespaceExports("ggplot2")) {
+  ggplot2::get_labs(p)
+} else {
+  p$labels
+}
+
 test_that("Plot layers match expectations",{
   expect_is(p$layers[[1]], "ggproto")
 })
@@ -12,11 +19,11 @@ test_that("Plot uses correct data",{
 })
 
 test_that("x axis is labeled 'displ'",{
-  expect_match(p$labels$x, "displ")
+  expect_match(labels$x, "displ")
 })
 
 test_that("y axis is labeled 'hwy'",{
-  expect_match(p$labels$y, "hwy")
+  expect_match(labels$y, "hwy")
 })
 
 


### PR DESCRIPTION
Hi there,

Apologies for not posting an issue first.
The ggplot2 package is planning an update for around May 2025 and a reverse dependency test identified a problem with the ezEDA package.
The details are explained in https://github.com/tidyverse/ggplot2/issues/6290, but essentially ggplot2 doesn't populate the `plot$labels` field before plot building anymore, which violates some test assumptions in this package.

This PR changes the tests to be compatible with both versions of ggplot2. 
Please note that due to plots getting build in ggplot2 3.6.0, some warnings can be emitted.
You can test the changes yourself with the development version of ggplot2 (`pak::pak("tidyverse/ggplot2")`)

Best,
Teun